### PR TITLE
fix(s2220): obsProc maxLength 200->999 conforme layout S-1.3

### DIFF
--- a/jsonSchemes/v_S_01_00_00/evtMonit.schema
+++ b/jsonSchemes/v_S_01_00_00/evtMonit.schema
@@ -81,7 +81,7 @@
                             "obsproc": {
                                 "required": false,
                                 "type": ["string","null"],
-                                "maxLength": 200
+                                "maxLength": 999
                             },
                             "ordexame": {
                                 "required": true,

--- a/jsonSchemes/v_S_01_01_00/evtMonit.schema
+++ b/jsonSchemes/v_S_01_01_00/evtMonit.schema
@@ -88,7 +88,7 @@
                                     "obsproc": {
                                         "required": false,
                                         "type": ["string","null"],
-                                        "maxLength": 200
+                                        "maxLength": 999
                                     },
                                     "ordexame": {
                                         "required": false,

--- a/jsonSchemes/v_S_01_02_00/evtMonit.schema
+++ b/jsonSchemes/v_S_01_02_00/evtMonit.schema
@@ -88,7 +88,7 @@
                                     "obsproc": {
                                         "required": false,
                                         "type": ["string","null"],
-                                        "maxLength": 200
+                                        "maxLength": 999
                                     },
                                     "ordexame": {
                                         "required": false,

--- a/jsonSchemes/v_S_01_03_00/evtMonit.schema
+++ b/jsonSchemes/v_S_01_03_00/evtMonit.schema
@@ -88,7 +88,7 @@
                                     "obsproc": {
                                         "required": false,
                                         "type": ["string","null"],
-                                        "maxLength": 200
+                                        "maxLength": 999
                                     },
                                     "ordexame": {
                                         "required": false,


### PR DESCRIPTION
JSON Schema de `evtMonit` limitava `obsproc` a 200 chars em todas as versoes (v_S_01_00_00 a v_S_01_03_00), divergindo do layout oficial eSocial S-1.3 e do proprio XSD do pacote (`TS_texto_999` = 999).

Exames com observacao > 200 chars (ex.: codigo 9999 / riscos psicossociais, texto padrao de 212 chars) eram rejeitados na validacao local antes do envio ao governo ("Conteudo do evento invalido").

Ref: eSocial Brasil card #10113

🤖 Generated with [Claude Code](https://claude.com/claude-code)